### PR TITLE
Check dismissible option before querying DOM

### DIFF
--- a/src/alerter.js
+++ b/src/alerter.js
@@ -40,7 +40,7 @@ Alerter.prototype.create = function (options) {
 
   this.emit('alertCreated', alert);
 
-  var closeButton = alert.querySelector('.alert__close-button');
+  var closeButton = options.dismissable && alert.querySelector('.alert__close-button');
 
   if (closeButton) {
     closeButton.addEventListener('click', function(){


### PR DESCRIPTION
Even though `dismissable` defaults to false, the create method still expects `.alert__close-button` to exist in the markup. I'm using a custom template that doesn't have this element, so it's blowing up with `Cannot read property 'querySelector' of null`. We should strengthen the check to see if the option is set first.
