### PR TITLE
add handlebars dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,13 @@
   },
   "dependencies": {
     "events": "^1.0.2",
-    "inherits": "^2.0.1",
-    "hbsfy": "^2.1.0"
+    "handlebars": "^3.0.0",
+    "hbsfy": "^2.1.0",
+    "inherits": "^2.0.1"
   },
   "browserify": {
-    "transform": [ "hbsfy" ]
+    "transform": [
+      "hbsfy"
+    ]
   }
 }


### PR DESCRIPTION
this was missing, and overlooked due to it being installed globally. hbsfy has this as a dependency but doesn't pull it in through package.json

fixes #7 